### PR TITLE
Improve variable dropdown responsiveness by saving settings on mousee…

### DIFF
--- a/code/map.js
+++ b/code/map.js
@@ -353,7 +353,8 @@ function registerEventHandlers() {
     });
 
     // Before switching variable: save current settings for the outgoing variable.
-    d3.select("#variableList").on("mousedown", function() {
+    // Use mouseenter so the save is already done before the click opens the dropdown.
+    d3.select("#variableList").on("mouseenter", function() {
         storeCurrentSettingsInData(data, colSelected, false);
     });
 


### PR DESCRIPTION
…nter

Moves the storeCurrentSettingsInData call from mousedown to mouseenter so the (potentially slow) save over all data rows is already done by the time the user clicks and the dropdown opens.

https://claude.ai/code/session_01UggFqBXHLQgHzDL38VZSEa